### PR TITLE
Secondary VJoy device never gets relinquished

### DIFF
--- a/Assets/Scripts/vJoyInterface.cs
+++ b/Assets/Scripts/vJoyInterface.cs
@@ -190,6 +190,7 @@ namespace EVRC
             if (vJoyStatus == VJoyStatus.Ready)
             {
                 vjoy.RelinquishVJD(deviceId);
+                vjoy.RelinquishVJD(secondaryDeviceId);
                 SetStatus(VJoyStatus.Unknown);
             }
         }


### PR DESCRIPTION
Fixed that the secondary device will never get relinquished