### PR TITLE
Haptic throttle deadzone

### DIFF
--- a/Assets/Scenes/EVRC.unity
+++ b/Assets/Scenes/EVRC.unity
@@ -3683,6 +3683,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   actionsController: {fileID: 1840785751}
+  hapticAction:
+    actionPath: /actions/default/out/Haptic
+    needsReinit: 0
 --- !u!1 &750486503
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/ActionsController/IBindingsController.cs
+++ b/Assets/Scripts/ActionsController/IBindingsController.cs
@@ -1,5 +1,6 @@
 ﻿namespace EVRC
 {
+    using Hand = ActionsController.Hand;
     using TrackpadInterval = ActionsController.TrackpadInterval;
 
     public enum BindingsHintCategory
@@ -17,5 +18,7 @@
         bool CanShowBindings();
         void ShowBindings(BindingsHintCategory hintCategory);
         void EditBindings();
+        IHaptics GetHapticsForHand(Hand hand);
+
     }
 }

--- a/Assets/Scripts/ActionsController/IHaptics.cs
+++ b/Assets/Scripts/ActionsController/IHaptics.cs
@@ -1,0 +1,8 @@
+namespace EVRC
+{
+    public interface IHaptics
+    {
+        void ThrottleDetent();
+    }
+}
+

--- a/Assets/Scripts/ActionsController/IHaptics.cs.meta
+++ b/Assets/Scripts/ActionsController/IHaptics.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6f7af7404357545e0896288d625b7ca0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ActionsControllerBindingsLoader.cs
+++ b/Assets/Scripts/ActionsControllerBindingsLoader.cs
@@ -109,5 +109,20 @@ namespace EVRC
                 Debug.LogWarning("Bindings Controller not available");
             }
         }
+
+        public IHaptics GetHapticsForHand(Hand hand)
+        {
+            var controller = CurrentController;
+            if (controller != null)
+            {
+                return CurrentController.GetHapticsForHand(hand);
+            }
+            else
+            {
+                Debug.LogWarning("Bindings Controller not available");
+                return null;
+            }
+        }
+
     }
 }

--- a/Assets/Scripts/ActionsController_SteamVRInputBindings.cs
+++ b/Assets/Scripts/ActionsController_SteamVRInputBindings.cs
@@ -20,6 +20,8 @@ namespace EVRC
     {
         public ActionsController actionsController;
 
+        public SteamVR_Action_Vibration hapticAction;
+
         private Dictionary<SteamVR_Action_Boolean, InputAction> booleanActionMap = new Dictionary<SteamVR_Action_Boolean, InputAction>();
         private Dictionary<SteamVR_Action_Vector2, InputAction> vector2ActionMap = new Dictionary<SteamVR_Action_Vector2, InputAction>();
         private Dictionary<SteamVR_Action_Boolean, InputAction> trackpadSlideTouchActionMap = new Dictionary<SteamVR_Action_Boolean, InputAction>();
@@ -492,7 +494,7 @@ namespace EVRC
 
         public IHaptics GetHapticsForHand(Hand hand)
         {
-            return new SteamVRHaptics(hand);
+            return new SteamVRHaptics(hapticAction, hand);
         }
     }
 }

--- a/Assets/Scripts/ActionsController_SteamVRInputBindings.cs
+++ b/Assets/Scripts/ActionsController_SteamVRInputBindings.cs
@@ -489,5 +489,10 @@ namespace EVRC
         {
             SteamVR_Input.OpenBindingUI();
         }
+
+        public IHaptics GetHapticsForHand(Hand hand)
+        {
+            return new SteamVRHaptics(hand);
+        }
     }
 }

--- a/Assets/Scripts/SteamVRHaptics.cs
+++ b/Assets/Scripts/SteamVRHaptics.cs
@@ -17,7 +17,7 @@ namespace EVRC
 
         public void ThrottleDetent()
         {
-            hapticAction.Execute(0, 0.15f, 20, 0.1f, inputSource);
+            hapticAction.Execute(0, 0.15f, 10, 0.15f, inputSource);
         }
     }
 }

--- a/Assets/Scripts/SteamVRHaptics.cs
+++ b/Assets/Scripts/SteamVRHaptics.cs
@@ -1,0 +1,22 @@
+using Valve.VR;
+
+namespace EVRC
+{
+    using Hand = ActionsController.Hand;
+
+    public class SteamVRHaptics : IHaptics
+    {
+        SteamVR_Action_Vibration hapticAction = new SteamVR_Action_Vibration();
+        SteamVR_Input_Sources inputSource;
+
+        public SteamVRHaptics(Hand hand)
+        {
+            inputSource = ActionsController_SteamVRInputBindings.GetInputSourceForHand(hand);
+        }
+
+        public void ThrottleDetent()
+        {
+            hapticAction.Execute(0, 0.15f, 20, 0.1f, inputSource);
+        }
+    }
+}

--- a/Assets/Scripts/SteamVRHaptics.cs
+++ b/Assets/Scripts/SteamVRHaptics.cs
@@ -6,11 +6,12 @@ namespace EVRC
 
     public class SteamVRHaptics : IHaptics
     {
-        SteamVR_Action_Vibration hapticAction = new SteamVR_Action_Vibration();
+        SteamVR_Action_Vibration hapticAction;
         SteamVR_Input_Sources inputSource;
 
-        public SteamVRHaptics(Hand hand)
+        public SteamVRHaptics(SteamVR_Action_Vibration hapticAction, Hand hand)
         {
+            this.hapticAction = hapticAction;
             inputSource = ActionsController_SteamVRInputBindings.GetInputSourceForHand(hand);
         }
 

--- a/Assets/Scripts/SteamVRHaptics.cs.meta
+++ b/Assets/Scripts/SteamVRHaptics.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 81884665787e44a3bac5d34201010119
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/VirtualThrottle.cs
+++ b/Assets/Scripts/VirtualThrottle.cs
@@ -163,7 +163,7 @@ namespace EVRC
             var throttle = localMagnitude / magnitudeLength;
             if (Mathf.Abs(throttle) < detentSize)
             {
-                handle.localPosition = Vector3.zero;
+                MoveThrottleToIdleDetent();
             }
             else
             {
@@ -222,6 +222,10 @@ namespace EVRC
                         state = ThrottleState.Forward;
                         EmitHapticDetent();
                     }
+                    else
+                    {
+                        MoveThrottleToIdleDetent();
+                    }
                     break;
 
                 case ThrottleState.Idle:
@@ -234,6 +238,10 @@ namespace EVRC
                     {
                         state = ThrottleState.Reverse;
                         EmitHapticDetent();
+                    }
+                    else
+                    {
+                        MoveThrottleToIdleDetent();
                     }
                     break;
 
@@ -248,6 +256,10 @@ namespace EVRC
                         state = ThrottleState.Reverse;
                         EmitHapticDetent();
                     }
+                    else
+                    {
+                        MoveThrottleToIdleDetent();
+                    }
                     break;
 
                 case ThrottleState.Reverse:
@@ -258,6 +270,11 @@ namespace EVRC
                     }
                     break;
             }
+        }
+
+        private void MoveThrottleToIdleDetent()
+        {
+            handle.localPosition = Vector3.zero;
         }
 
         private void EmitHapticDetent()

--- a/Assets/Scripts/VirtualThrottle.cs
+++ b/Assets/Scripts/VirtualThrottle.cs
@@ -279,7 +279,10 @@ namespace EVRC
 
         private void EmitHapticDetent()
         {
-            // TODO emit a haptic pulse for the attached controller
+            var attachment = attachedInteractionPoint;
+            var haptics = ActionsControllerBindingsLoader.CurrentBindingsController
+                .GetHapticsForHand(attachment.Hand);
+            haptics.ThrottleDetent();
         }
     }
 }

--- a/Assets/Scripts/VirtualThrottle.cs
+++ b/Assets/Scripts/VirtualThrottle.cs
@@ -194,7 +194,7 @@ namespace EVRC
         {
             get
             {
-                return 2 * detentSize;
+                return 3 * detentSize;
             }
         }
 

--- a/Assets/Scripts/VirtualThrottle.cs
+++ b/Assets/Scripts/VirtualThrottle.cs
@@ -159,17 +159,15 @@ namespace EVRC
             var t = attachPoint;
             handle.position = t.position;
 
-            var throttle = Mathf.Clamp(handle.localPosition.z, -magnitudeLength, magnitudeLength);
-            if (Mathf.Abs(throttle) < output.throttleDeadzonePercentage)
+            var localMagnitude = Mathf.Clamp(handle.localPosition.z, -magnitudeLength, magnitudeLength);
+            var throttle = localMagnitude / magnitudeLength;
+            if (Mathf.Abs(throttle) < detentSize)
             {
                 handle.localPosition = Vector3.zero;
             }
             else
             {
-                handle.localPosition = new Vector3(
-                        0,
-                        0,
-                        throttle * magnitudeLength);
+                handle.localPosition = new Vector3(0, 0, localMagnitude);
             }
 
             CheckStateChange(throttle);
@@ -188,7 +186,7 @@ namespace EVRC
         {
             get
             {
-                return output.throttleDeadzonePercentage;
+                return output.throttleDeadzonePercentage / 100f;
             }
         }
 

--- a/Assets/Scripts/VirtualThrottle.cs
+++ b/Assets/Scripts/VirtualThrottle.cs
@@ -1,8 +1,16 @@
-﻿using System;
-using UnityEngine;
+﻿using UnityEngine;
 
 namespace EVRC
 {
+    enum ThrottleState
+    {
+        Forward,
+        ForwardIdleDetent,
+        Idle,
+        ReverseIdleDetent,
+        Reverse,
+    }
+
     /**
      * A virtual 1-axis movable throttle that outputs to vJoy when grabbed
      */
@@ -21,6 +29,7 @@ namespace EVRC
         private bool highlighted = false;
         private ControllerInteractionPoint attachedInteractionPoint;
         private Transform attachPoint;
+        private ThrottleState state = ThrottleState.Idle;
 
         public GrabMode GetGrabMode()
         {
@@ -93,6 +102,13 @@ namespace EVRC
                 {
                     buttons.Ungrabbed();
                 }
+
+                var throttle = handle.localPosition.z / magnitudeLength;
+                if (Mathf.Abs(throttle) < output.throttleDeadzonePercentage)
+                {
+                    handle.localPosition = Vector3.zero;
+                    state = ThrottleState.Idle;
+                }
             }
         }
 
@@ -142,10 +158,21 @@ namespace EVRC
 
             var t = attachPoint;
             handle.position = t.position;
-            handle.localPosition = new Vector3(
-                0,
-                0,
-                Mathf.Clamp(handle.localPosition.z, -magnitudeLength, magnitudeLength));
+
+            var throttle = Mathf.Clamp(handle.localPosition.z, -magnitudeLength, magnitudeLength);
+            if (Mathf.Abs(throttle) < output.throttleDeadzonePercentage)
+            {
+                handle.localPosition = Vector3.zero;
+            }
+            else
+            {
+                handle.localPosition = new Vector3(
+                        0,
+                        0,
+                        throttle * magnitudeLength);
+            }
+
+            CheckStateChange(throttle);
         }
 
         void Update()
@@ -155,6 +182,89 @@ namespace EVRC
 
             var throttle = handle.localPosition.z / magnitudeLength;
             output.SetThrottle(throttle);
+        }
+
+        private float detentSize
+        {
+            get
+            {
+                return output.throttleDeadzonePercentage;
+            }
+        }
+
+        private float reverseDetentSize
+        {
+            get
+            {
+                return 2 * detentSize;
+            }
+        }
+
+
+        private void CheckStateChange(float throttle)
+        {
+            switch (state)
+            {
+                case ThrottleState.Forward:
+                    if (throttle < detentSize)
+                    {
+                        state = ThrottleState.ForwardIdleDetent;
+                        EmitHapticDetent();
+                    }
+                    break;
+
+                case ThrottleState.ForwardIdleDetent:
+                    if (throttle < -reverseDetentSize)
+                    {
+                        state = ThrottleState.Reverse;
+                        EmitHapticDetent();
+                    }
+                    else if (throttle > detentSize)
+                    {
+                        state = ThrottleState.Forward;
+                        EmitHapticDetent();
+                    }
+                    break;
+
+                case ThrottleState.Idle:
+                    if (throttle > detentSize)
+                    {
+                        state = ThrottleState.Forward;
+                        EmitHapticDetent();
+                    }
+                    else if (throttle < -detentSize)
+                    {
+                        state = ThrottleState.Reverse;
+                        EmitHapticDetent();
+                    }
+                    break;
+
+                case ThrottleState.ReverseIdleDetent:
+                    if (throttle > reverseDetentSize)
+                    {
+                        state = ThrottleState.Forward;
+                        EmitHapticDetent();
+                    }
+                    else if (throttle < -detentSize)
+                    {
+                        state = ThrottleState.Reverse;
+                        EmitHapticDetent();
+                    }
+                    break;
+
+                case ThrottleState.Reverse:
+                    if (throttle > -detentSize)
+                    {
+                        state = ThrottleState.ReverseIdleDetent;
+                        EmitHapticDetent();
+                    }
+                    break;
+            }
+        }
+
+        private void EmitHapticDetent()
+        {
+            // TODO emit a haptic pulse for the attached controller
         }
     }
 }


### PR DESCRIPTION
Hello! Not sure how you'll feel about this approach but I think it feels pretty good. If you don't like the haptics but are interested in the controller behavior changes, there's another branch that's this but without the haptic stuff.

Here's an explanation from the commits:

    The direction the throttle first leaves the deadzone from determines its
    initial state, IE: Forward or Reverse. In this state, it is easy to fall
    back into an associated "idle detent" state by moving the throttle
    within the deadzone, eg: ForwardIdleDetent or ReverseIdleDetent.

    From the "idle detent" state, it is easy to move into the associated
    acceleration state, but "hard" to move to the opposite acceleration
    state.

    Transition between states can be made clear to the user by use of haptic
    events.

    This mechanism enables you to quickly move from forward to reverse if
    you need to, while also making it easy to find (and not move past!)
    idle.

This PR also makes it more clear when you're in the idle deadzone by keeping the throttle UI idle while within it, and adds some initial haptic feedback when you leave and enter the deadzone. The haptic API is designed to continue the work you've started to keep the controller interactions platform agnostic and keep the door open for a non-SteamVR implementation. I haven't spent a lot of time tweaking the actual haptic feedback, but there it's a place to start.