### PR TITLE
added missing key codes

### DIFF
--- a/Assets/Scripts/KeyboardInterface.cs
+++ b/Assets/Scripts/KeyboardInterface.cs
@@ -124,15 +124,15 @@ namespace EVRC
             //{ "Key_", VirtualKeyCode.DIVIDE },
             // Key_Equals does not appear to be present in VirtualKeyCode, or is it OEM_PLUS?
             { "Key_Equals", VirtualKeyCode.OEM_PLUS },
-            //{ "Key_", VirtualKeyCode.OEM_COMMA },
+            { "Key_Comma", VirtualKeyCode.VK_OEM_COMMA },
             { "Key_Minus", VirtualKeyCode.OEM_MINUS },
-            //{ "Key_", VirtualKeyCode.OEM_PERIOD },
+            { "Key_Period", VirtualKeyCode.VK_OEM_PERIOD },
             { "Key_Slash", VirtualKeyCode.OEM_2 },
             //{ "Key_", VirtualKeyCode.OEM_3 },
             //{ "Key_", VirtualKeyCode.OEM_4 },
             //{ "Key_", VirtualKeyCode.OEM_5 },
             //{ "Key_", VirtualKeyCode.OEM_6 },
-            //{ "Key_", VirtualKeyCode.OEM_7 },
+            { "Key_Apostrophe", VirtualKeyCode.OEM_7 },
             //{ "Key_", VirtualKeyCode.OEM_102 },
             //{ "Key_BackSlash", VirtualKeyCode. },
         };

--- a/Assets/WindowsInput/Native/VirtualKeyCode.cs
+++ b/Assets/WindowsInput/Native/VirtualKeyCode.cs
@@ -1,7 +1,7 @@
 ﻿namespace WindowsInput.Native
 {
     /// <summary>
-    /// The list of VirtualKeyCodes (see: http://msdn.microsoft.com/en-us/library/ms645540(VS.85).aspx)
+    /// The list of VirtualKeyCodes (see: https://docs.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes)
     /// </summary>
     public enum VirtualKeyCode //: UInt16
     {
@@ -797,7 +797,7 @@
         /// <summary>
         /// Windows 2000/XP: For any country/region, the ',' key
         /// </summary>
-        OEM_COMMA = 0xBC,
+        VK_OEM_COMMA = 0xBC,
 
         /// <summary>
         /// Windows 2000/XP: For any country/region, the '-' key
@@ -807,7 +807,7 @@
         /// <summary>
         /// Windows 2000/XP: For any country/region, the '.' key
         /// </summary>
-        OEM_PERIOD = 0xBE,
+        VK_OEM_PERIOD = 0xBE,
 
         /// <summary>
         /// Used for miscellaneous characters; it can vary by keyboard. Windows 2000/XP: For the US standard keyboard, the '/?' key 


### PR DESCRIPTION
Added the following VirtualKeyCode mappings:
Apostrophe (Quote)
Period
Comma

Microsoft has an updated doc on this, which includes the formerly missing values. I assume this is understood, but these keys, in particular, appear to have issues with non-English keyboards